### PR TITLE
Xalan-J support

### DIFF
--- a/src/main/java/net/javacrumbs/json2xml/JsonXmlReader.java
+++ b/src/main/java/net/javacrumbs/json2xml/JsonXmlReader.java
@@ -79,8 +79,7 @@ public class JsonXmlReader implements XMLReader {
     }
 
     public void setDTDHandler(DTDHandler handler) {
-        throw new UnsupportedOperationException();
-
+        //ignore
     }
 
     public DTDHandler getDTDHandler() {


### PR DESCRIPTION
Add support for Xalan-J by ignoring requests to set the  DTDHandler rather than throw an exception.  If you follow the instructions all is good when using vanilla JRE/JDK, but if you (like me) are using Xalan-J (2.7.1) an UnsupportedOperationException is thrown by the JsonXmlReader .  With this change, requests to set the DTD handler are just ignored, which allows the provided examples to work either with the vanilla Java or with Xalan-J
